### PR TITLE
refactor: complete async migration and remove unnecessary methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Revion is a library for CQRS/Event Sourcing.",
   "module": "index.ts",
   "type": "module",
-  "version": "0.0.11",
+  "version": "0.0.13",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",

--- a/src/eventListener.ts
+++ b/src/eventListener.ts
@@ -23,7 +23,7 @@ function mergePolicy<E extends ReducerEvent>(
 function mergeProjection<E extends ReducerEvent>(
   projections: CaseProjections<E>
 ): Projection<E> {
-  return (event: E): void => {
+  return async (event: E): Promise<void> => {
     const fn = projections[event.type as keyof typeof projections]
     if (fn) {
       return fn(event as Extract<E, { type: E['type'] }>)

--- a/src/types/eventListener.ts
+++ b/src/types/eventListener.ts
@@ -9,7 +9,7 @@ export type CasePolicies<E extends ReducerEvent> = {
   [K in E['type']]: Policy<Extract<E, { type: K }>>
 }
 
-export type Projection<E extends ReducerEvent> = (event: E) => void
+export type Projection<E extends ReducerEvent> = (event: E) => Promise<void>
 
 export type CaseProjections<E extends ReducerEvent> = {
   [K in E['type']]: Projection<Extract<E, { type: K }>>

--- a/tests/mock/eventStoreInMemory.ts
+++ b/tests/mock/eventStoreInMemory.ts
@@ -10,10 +10,6 @@ export class EventStoreInMemory implements EventStore {
     )
   }
 
-  all(): Event[] {
-    return this.events
-  }
-
   async save(events: Event[]) {
     this.events.push(...events)
   }


### PR DESCRIPTION
## Ticket / Issue Number

## Changes

- Converted `mergeProjection` to return a Promise
- Updated `EventStoreInMemory` and `integrationTest` to fully support async workflows
- Removed `all()` method from event store implementations
- Bumped package version to 0.0.13

## Notes
