### PR TITLE
Allow custom aggregate ID creation

### DIFF
--- a/src/command/combined.ts
+++ b/src/command/combined.ts
@@ -13,7 +13,12 @@ import { createApplyEventFnFactory } from './fn/apply-event'
 import { createReplayEventFnFactory } from './fn/replay-event'
 import { createSaveEventFnFactory } from './fn/save-event'
 
-type CombinedReplayEventFn = <S extends State>(id: AggregateId) => Promise<ExtendedState<S> | null>
+import type { ReplayEventOptions } from './fn/replay-event'
+
+type CombinedReplayEventFn = <S extends State>(
+  id: AggregateId,
+  options?: ReplayEventOptions
+) => Promise<ExtendedState<S> | null>
 
 export type CombinedApplyEventFn = <S extends State, C extends Command, E extends DomainEvent>(
   state: ExtendedState<S>,
@@ -40,7 +45,10 @@ export function createCombinedReplayFn(
   deps: CommandHandlerDeps,
   aggregates: AnyAggregate[]
 ): CombinedReplayEventFn {
-  return async <S extends State>(id: AggregateId): Promise<ExtendedState<S> | null> => {
+  return async <S extends State>(
+    id: AggregateId,
+    options?: ReplayEventOptions
+  ): Promise<ExtendedState<S> | null> => {
     let aggregate: AnyAggregate | undefined
     for (const agg of aggregates) {
       if (agg.type === id.type) {
@@ -53,7 +61,8 @@ export function createCombinedReplayFn(
     }
 
     const result = await createReplayEventFnFactory(aggregate.stateInit, aggregate.reducer)(deps)(
-      id
+      id,
+      options
     )
     if (!result.ok) return null
 

--- a/src/command/command-handler.ts
+++ b/src/command/command-handler.ts
@@ -42,7 +42,9 @@ function createCommandHandlerFactory<
     const saveFn = createSaveEventFnFactory<S, E, D>()(deps)
 
     return async (command: Command): AsyncResult<void, AppError> => {
-      const replayed = await replayFn(command.id as AggregateId<T>)
+      const replayed = await replayFn(command.id as AggregateId<T>, {
+        createWhenNotFound: command.isNew
+      })
       if (!replayed.ok) return replayed
 
       const applied = await applyFn(replayed.value, command as C)

--- a/src/types/command.ts
+++ b/src/types/command.ts
@@ -12,6 +12,7 @@ export type ExtendedState<T extends State> = {
 export type Command = {
   readonly operation: string
   readonly id: AggregateId
+  readonly isNew?: boolean
   readonly payload?: unknown
 }
 

--- a/tests/unit/command/command-handler.test.ts
+++ b/tests/unit/command/command-handler.test.ts
@@ -39,6 +39,26 @@ describe('command handler', () => {
       expect(result.ok).toBe(true)
     })
 
+    it('should create state when id provided and isNew flag set', async () => {
+      // Arrange
+      const handlers = createCommandHandlers(
+        { eventStore: new EventStoreInMemory() },
+        [counter],
+        [mergeCounter]
+      )
+      const command: Command = {
+        id: { type: 'counter', id: '00000000-0000-0000-0000-000000000010' },
+        operation: 'increment',
+        isNew: true
+      }
+
+      // Act
+      const result = await handlers[command.id.type](command)
+
+      // Assert
+      expect(result.ok).toBe(true)
+    })
+
     it('should return error if replay event failed', async () => {
       // Arrange
       const es = new EventStoreInMemory()

--- a/tests/unit/command/fn/replay-event.test.ts
+++ b/tests/unit/command/fn/replay-event.test.ts
@@ -143,6 +143,27 @@ describe('replay event function', () => {
     }
   })
 
+  it('should initialize state when no events and create flag given', async () => {
+    // Arrange
+    const es = new EventStoreInMemory()
+    const deps = { eventStore: es }
+    const replayEventFn = createReplayEventFnFactory(counter.stateInit, counter.reducer)(deps)
+
+    // Act
+    const res = await replayEventFn(
+      { type: 'counter', id: '00000000-0000-0000-0000-000000000010' },
+      { createWhenNotFound: true }
+    )
+
+    // Assert
+    const expected = ok({
+      state: { id: { type: 'counter', id: '00000000-0000-0000-0000-000000000010' }, count: 0 },
+      version: 0
+    } as ExtendedState<CounterState>)
+
+    expect(res).toEqual(expected)
+  })
+
   it('should return error when snapshot cannot be loaded', async () => {
     // Arrange
     const es = new EventStoreInMemory()


### PR DESCRIPTION
## Summary
- add optional flag to allow initializing a state when no events exist
- accept replay options in combined replay and command handler
- expose `isNew` on commands to mark creation intent
- test creating with custom IDs

## Testing
- `bun install`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6852aa1682ec83269e7d7944338d85c5