### PR TITLE
Fix snapshot retrieval to return latest version

### DIFF
--- a/src/utils/event-store-in-memory.ts
+++ b/src/utils/event-store-in-memory.ts
@@ -36,11 +36,14 @@ export class EventStoreInMemory implements EventStore {
   }
 
   async getSnapshot<S extends State>(aggregateId: AggregateId): Promise<Snapshot<S> | null> {
-    const snapshot = this.snapshots.find(
-      snapshot =>
-        snapshot.state.id.type === aggregateId.type && snapshot.state.id.id === aggregateId.id
-    )
-    return snapshot as Snapshot<S> | null
+    const snapshot = this.snapshots
+      .filter(
+        s =>
+          s.state.id.type === aggregateId.type && s.state.id.id === aggregateId.id
+      )
+      .sort((a, b) => b.version - a.version)[0]
+
+    return (snapshot ?? null) as Snapshot<S> | null
   }
 
   async saveSnapshot<S extends State>(snapshot: Snapshot<S>): Promise<void> {


### PR DESCRIPTION
## Summary
- update `EventStoreInMemory.getSnapshot` to return the most recent snapshot for a given aggregate ID

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6852a82cc3948326a91a035f5b8b9b2b