### PR TITLE
Update aggregate ID handling and improve type exports

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -42,7 +42,7 @@
   "javascript": {
     "formatter": {
       "arrowParentheses": "asNeeded",
-      "bracketSameLine": false,
+      "bracketSameLine": true,
       "bracketSpacing": true,
       "jsxQuoteStyle": "double",
       "quoteProperties": "asNeeded",

--- a/src/command/fn/replay-event.ts
+++ b/src/command/fn/replay-event.ts
@@ -1,4 +1,3 @@
-import { v4 } from 'uuid'
 import type {
   AggregateId,
   AppError,
@@ -9,6 +8,8 @@ import type {
   State,
   StateInitFn
 } from '../../types'
+import { v4 } from 'uuid'
+import { isZero } from '../../types'
 import { err, ok, toAsyncResult } from '../../utils'
 import type { CommandHandlerDeps } from '../command-handler'
 
@@ -24,10 +25,10 @@ export function createReplayEventFnFactory<
 >(stateInit: StateInitFn<T, S>, reducer: ReducerFn<S, E>): (deps: D) => ReplayEventFn<T, S> {
   return (deps: D) => {
     return async (id: AggregateId<T>) => {
-      if (id.id === '00000000-0000-0000-0000-000000000000') {
-        const uuid = v4()
+      if (isZero(id)) {
+        const newId = v4()
         return ok({
-          state: stateInit({ type: id.type, id: uuid }) as S,
+          state: stateInit({ ...id, id: newId }) as S,
           version: 0
         })
       }

--- a/src/fixture/aggregate-fixture.ts
+++ b/src/fixture/aggregate-fixture.ts
@@ -13,7 +13,7 @@ import type {
   State,
   ViewMap
 } from '../types'
-import { zeroId } from '../utils/aggregate-id'
+import { zeroId } from '../types'
 import { FakeHandler } from './fake-handler'
 
 type AggregateTestContext<S extends State, E extends DomainEvent> = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,4 +26,5 @@ export type {
   CaseReducerFn as Reducer,
   GetListOptions
 } from './types'
+export { id, zeroId } from './types'
 export * from './utils'

--- a/src/types/aggregate-id.ts
+++ b/src/types/aggregate-id.ts
@@ -1,4 +1,37 @@
+declare const __brand: unique symbol
+type Brand = { readonly [__brand]: 'AggregateId' }
+
+const zeroUUID = '00000000-0000-0000-0000-000000000000'
+
 export type AggregateId<T extends string = string> = {
   readonly type: T
   readonly id: string
+} & Brand
+
+export function id<T extends string>(type: T, id: string): AggregateId<T> {
+  return {
+    type,
+    id
+  } as AggregateId<T>
+}
+
+export function zeroId<T extends string>(type: T): AggregateId<T> {
+  return {
+    type,
+    id: zeroUUID
+  } as AggregateId<T>
+}
+
+export function isAggregateId(value: unknown): value is AggregateId {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const obj = value as Brand
+
+  return '__brand' in obj && obj[__brand] === 'AggregateId'
+}
+
+export function isZero(value: AggregateId) {
+  return value.id === zeroUUID
 }

--- a/src/utils/aggregate-id.ts
+++ b/src/utils/aggregate-id.ts
@@ -26,10 +26,3 @@ export function validateAggregateId(id: AggregateId): Result<void, AppError> {
 export function isEqualId(id1: AggregateId, id2: AggregateId): boolean {
   return id1.type === id2.type && id1.id === id2.id
 }
-
-export function zeroId(type: string): AggregateId {
-  return {
-    type: type,
-    id: '00000000-0000-0000-0000-000000000000'
-  }
-}

--- a/tests/command/command-bus.test.ts
+++ b/tests/command/command-bus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { EventStoreInMemory, createCommandBus } from '../../src'
+import { EventStoreInMemory, createCommandBus, id, zeroId } from '../../src'
 import type { CommandHandlerMiddleware } from '../../src/command/command-bus'
 import { counter } from '../data/command/counter'
 import { mergeCounter } from '../data/command/mergeCounter'
@@ -14,7 +14,7 @@ describe('command bus', () => {
       // Act
       const res = await dispatch({
         operation: 'increment',
-        id: { type: 'counter', id: '00000000-0000-0000-0000-000000000000' }
+        id: zeroId('counter')
       })
 
       // Assert
@@ -25,13 +25,13 @@ describe('command bus', () => {
       // Arrange
       const es = new EventStoreInMemory()
       es.events.push({
-        aggregateId: { type: 'counter', id: '00000000-0000-0000-0000-000000000001' },
+        aggregateId: id('counter', '00000000-0000-0000-0000-000000000001'),
         version: 1,
         event: { type: 'incremented' },
         timestamp: new Date()
       })
       es.events.push({
-        aggregateId: { type: 'counter', id: '00000000-0000-0000-0000-000000000002' },
+        aggregateId: id('counter', '00000000-0000-0000-0000-000000000002'),
         version: 1,
         event: { type: 'incremented' },
         timestamp: new Date()
@@ -42,10 +42,10 @@ describe('command bus', () => {
       // Act
       const result = await dispatch({
         operation: 'mergeCounter',
-        id: { type: 'mergeCounter', id: '00000000-0000-0000-0000-000000000000' },
+        id: zeroId('mergeCounter'),
         payload: {
-          fromCounterId: { type: 'counter', id: '00000000-0000-0000-0000-000000000001' },
-          toCounterId: { type: 'counter', id: '00000000-0000-0000-0000-000000000002' }
+          fromCounterId: id('counter', '00000000-0000-0000-0000-000000000001'),
+          toCounterId: id('counter', '00000000-0000-0000-0000-000000000002')
         }
       })
 
@@ -75,7 +75,7 @@ describe('command bus', () => {
       // Act
       const result = await bus({
         operation: 'increment',
-        id: { type: 'counter', id: '00000000-0000-0000-0000-000000000000' }
+        id: zeroId('counter')
       })
 
       // Assert
@@ -93,7 +93,7 @@ describe('command bus', () => {
       // Act
       const result = await dispatch({
         operation: '',
-        id: { type: 'counter', id: '00000000-0000-0000-0000-000000000001' }
+        id: id('counter', '00000000-0000-0000-0000-000000000001')
       })
 
       // Assert
@@ -111,7 +111,7 @@ describe('command bus', () => {
       // Act
       const result = await dispatch({
         operation: 'increment',
-        id: { type: 'counter', id: '' }
+        id: id('counter', '')
       })
 
       // Assert
@@ -129,7 +129,7 @@ describe('command bus', () => {
       // Act
       const result = await dispatch({
         operation: 'increment',
-        id: { type: 'unknown', id: '00000000-0000-0000-0000-000000000001' }
+        id: id('unknown', '00000000-0000-0000-0000-000000000001')
       })
 
       // Assert

--- a/tests/data/command/counter/aggregate.test.ts
+++ b/tests/data/command/counter/aggregate.test.ts
@@ -1,18 +1,14 @@
 import { describe, expect, test } from 'bun:test'
-import { aggregateFixture } from '../../../../src'
+import { aggregateFixture, id, zeroId } from '../../../../src'
 import { counter } from './aggregate'
 import { counterReactor } from './event-reactor'
 
-const zeroId = '00000000-0000-0000-0000-000000000000'
 const uuid1 = '00000000-0000-0000-0000-000000000001'
 
 describe('counter aggregate tests', () => {
   test('create', () => {
     aggregateFixture(counter, counterReactor)
-      .when({
-        operation: 'create',
-        id: { type: 'counter', id: zeroId }
-      })
+      .when({ operation: 'create', id: zeroId('counter') })
       .then(fixture => {
         fixture.assert(ctx => {
           expect(ctx.error).toBeNull()
@@ -25,14 +21,11 @@ describe('counter aggregate tests', () => {
 
   test('increment and decrement', () => {
     aggregateFixture(counter, counterReactor)
-      .givenId({ type: 'counter', id: uuid1 })
+      .givenId(id('counter', uuid1))
       .given({ type: 'created' })
       .given({ type: 'incremented' })
       .given({ type: 'decremented' })
-      .when({
-        operation: 'increment',
-        id: { type: 'counter', id: uuid1 }
-      })
+      .when({ operation: 'increment', id: id('counter', uuid1) })
       .then(fixture => {
         fixture.assert(ctx => {
           expect(ctx.error).toBeNull()
@@ -43,12 +36,9 @@ describe('counter aggregate tests', () => {
       })
 
     aggregateFixture(counter, counterReactor)
-      .givenId({ type: 'counter', id: uuid1 })
+      .givenId(id('counter', uuid1))
       .givenMany([{ type: 'created' }, { type: 'incremented' }, { type: 'decremented' }])
-      .when({
-        operation: 'increment',
-        id: { type: 'counter', id: uuid1 }
-      })
+      .when({ operation: 'increment', id: id('counter', uuid1) })
       .then(fixture => {
         fixture.assert(ctx => {
           expect(ctx.error).toBeNull()
@@ -61,9 +51,9 @@ describe('counter aggregate tests', () => {
 
   test('create and delete', () => {
     aggregateFixture(counter, counterReactor)
-      .givenId({ type: 'counter', id: uuid1 })
+      .givenId(id('counter', uuid1))
       .given({ type: 'created' })
-      .when({ operation: 'delete', id: { type: 'counter', id: uuid1 } })
+      .when({ operation: 'delete', id: id('counter', uuid1) })
       .then(fixture => {
         fixture.assert(ctx => {
           expect(ctx.error).toBeNull()


### PR DESCRIPTION
## Changes

- Change bracketSameLine option in formatter to true in biome.json
- Export id and zeroId functions from types in index.ts
- Refactor replay-event.ts to use isZero function for ID validation
- Move zeroId import from utils to types in aggregate-fixture.ts
- Enhance aggregate-id.ts with new functions for ID handling
- Remove obsolete zeroId function from utils
- Update tests to utilize new id and zeroId functions for consistency
